### PR TITLE
Add fixture factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Development stuff
+.vscode

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,0 +1,3 @@
+[pydocstyle]
+convention = numpy
+match = '(?!test_).*\.py'

--- a/candystore/__init__.py
+++ b/candystore/__init__.py
@@ -1,0 +1,1 @@
+"""Factories for randomised AFL data sets for testing purposes."""

--- a/candystore/fixtures.py
+++ b/candystore/fixtures.py
@@ -1,0 +1,280 @@
+"""For generating fake fixture data."""
+
+from typing import Tuple, Union, List, cast
+from datetime import date, datetime, timedelta
+from itertools import chain
+import math
+from functools import partial
+
+from faker import Faker
+from mypy_extensions import TypedDict
+import numpy as np
+
+
+SeasonRange = Tuple[int, int]
+FixtureData = TypedDict(
+    "FixtureData",
+    {
+        "date": str,
+        "season": int,
+        "season_game": int,
+        "round": int,
+        "home_team": str,
+        "away_team": str,
+        "venue": str,
+    },
+)
+DateRange = TypedDict(
+    "DateRange", {"datetime_start": datetime, "datetime_end": datetime}
+)
+
+
+FAKE = Faker()
+
+FIRST_AFL_SEASON = 1897
+MAR = 3
+FIFTEENTH = 15
+SEP = 9
+THIRTIETH = 30
+WEDNESDAY = 2
+# About as early as matches ever start
+MIN_MATCH_HOUR = 12
+# About as late as matches ever start
+MAX_MATCH_HOUR = 20
+
+WEEK_IN_DAYS = 7
+DAY_IN_HOURS = 24
+
+TEAMS = [
+    "Richmond",
+    "Carlton",
+    "Melbourne",
+    "Greater Western Sydney",
+    "Essendon",
+    "Sydney",
+    "Collingwood",
+    "North Melbourne",
+    "Western Bulldogs",
+    "Fremantle",
+    "Port Adelaide",
+    "St Kilda",
+    "Hawthorn",
+    "Adelaide",
+    "Brisbane Bears",
+    "Brisbane Lions",
+    "Gold Coast",
+    "Geelong",
+    "West Coast",
+    "Fitzroy",
+    "University",
+]
+
+VENUES = [
+    # AFL Tables venues
+    "Football Park",
+    "S.C.G.",
+    "Windy Hill",
+    "Subiaco",
+    "Moorabbin Oval",
+    "M.C.G.",
+    "Kardinia Park",
+    "Victoria Park",
+    "Waverley Park",
+    "Princes Park",
+    "Western Oval",
+    "W.A.C.A.",
+    "Carrara",
+    "Gabba",
+    "Docklands",
+    "York Park",
+    "Manuka Oval",
+    "Sydney Showground",
+    "Adelaide Oval",
+    "Bellerive Oval",
+    "Marrara Oval",
+    "Traeger Park",
+    "Perth Stadium",
+    "Stadium Australia",
+    "Wellington",
+    "Lake Oval",
+    "East Melbourne",
+    "Corio Oval",
+    "Junction Oval",
+    "Brunswick St",
+    "Punt Rd",
+    "Glenferrie Oval",
+    "Arden St",
+    "Olympic Park",
+    "Yarraville Oval",
+    "Toorak Park",
+    "Euroa",
+    "Coburg Oval",
+    "Brisbane Exhibition",
+    "North Hobart",
+    "Bruce Stadium",
+    "Yallourn",
+    "Cazaly's Stadium",
+    "Eureka Stadium",
+    "Blacktown",
+    "Jiangwan Stadium",
+    "Albury",
+    "Riverway Stadium",
+    # Footywire venues
+    "AAMI Stadium",
+    "ANZ Stadium",
+    "UTAS Stadium",
+    "Blacktown International",
+    "Blundstone Arena",
+    "Domain Stadium",
+    "Etihad Stadium",
+    "GMHBA Stadium",
+    "MCG",
+    "Mars Stadium",
+    "Metricon Stadium",
+    "Optus Stadium",
+    "SCG",
+    "Spotless Stadium",
+    "TIO Stadium",
+    "Westpac Stadium",
+    "Marvel Stadium",
+    "Canberra Oval",
+    # Correct spelling is 'Traeger', but footywire.com is spelling it 'Traegar' in its
+    # fixtures
+    "TIO Traegar Park",
+]
+
+
+def _generate_match(
+    round_number: int,
+    round_start_date: datetime,
+    match_number: int,
+    teams: Tuple[str, str] = cast(Tuple[str, str], tuple(np.random.choice(TEAMS, 2))),
+    venue: str = np.random.choice(VENUES),
+) -> FixtureData:
+    raw_match_date_time = FAKE.date_time_between_dates(
+        datetime_start=round_start_date,
+        datetime_end=(round_start_date + timedelta(days=WEEK_IN_DAYS)),
+    )
+    # We need to generate the time separately to make sure we have
+    # a realistic start time for the match on the randomly-generated day.
+    raw_match_time = FAKE.date_time_between_dates(
+        datetime_start=raw_match_date_time.replace(
+            hour=MIN_MATCH_HOUR, minute=0, second=0
+        ),
+        datetime_end=raw_match_date_time.replace(
+            hour=MAX_MATCH_HOUR, minute=0, second=0
+        ),
+    ).time()
+
+    match_date_time = raw_match_date_time.replace(
+        hour=raw_match_time.hour,
+        minute=raw_match_time.minute,
+        second=raw_match_time.second,
+    )
+
+    home_team, away_team = teams
+
+    return {
+        "date": str(match_date_time),
+        "season": match_date_time.year,
+        "season_game": match_number,
+        "round": round_number,
+        "home_team": home_team,
+        "away_team": away_team,
+        "venue": venue,
+    }
+
+
+def _generate_round(season_start: datetime, week: int) -> List[FixtureData]:
+    round_start = season_start + timedelta(days=(WEEK_IN_DAYS * week))
+    round_number = week + 1
+
+    team_count = len(TEAMS)
+    match_count = math.floor(team_count / 2)
+    min_match_number = (week * match_count) + 1
+    max_match_number = min_match_number + match_count
+
+    teams = (team for team in np.random.permutation(TEAMS))
+    venues = (venue for venue in np.random.permutation(VENUES))
+
+    match_data_func = partial(_generate_match, round_number, round_start,)
+
+    return [
+        match_data_func(
+            match_number, teams=(next(teams), next(teams)), venue=next(venues)
+        )
+        for match_number in range(min_match_number, max_match_number)
+    ]
+
+
+def _generate_season(season: int) -> List[FixtureData]:
+    # Seasons have typically started in mid-to-late March since the 70s
+    start_date = datetime(season, MAR, FIFTEENTH)
+    # Typically, rounds start on Thursday or Friday and end on Sunday,
+    # but can range from Wednesday to Tuesday, with a few exceptions.
+    difference_from_wed = WEDNESDAY - start_date.weekday()
+    season_start = start_date + timedelta(days=difference_from_wed)
+
+    # Seasons typically end somewhere between mid September and mid October,
+    # so we split the difference.
+    season_end = datetime(season, SEP, THIRTIETH)
+    week_count = math.floor((season_end - season_start).days / WEEK_IN_DAYS)
+
+    return list(
+        chain.from_iterable(
+            [_generate_round(season_start, week) for week in range(week_count)]
+        )
+    )
+
+
+def generate(seasons: Union[int, SeasonRange] = 1) -> List[FixtureData]:
+    """
+    Generate fixture data for the given seasons.
+
+    Params:
+    -------
+    seasons: The seasons to generate data for.
+        If an integer, will start from a random year for which AFL data exists
+        and increment for the given number of years.
+        If a tuple of integers, will generate fixtures for the given range of years
+        (same rules as Python's `range`).
+
+    Returns:
+    --------
+    List of fixture dictionaries that replicate fitzRoy's `get_fixture` function,
+        but with Pythonic conventions (e.g. snake_case keys)
+    """
+    current_year = date.today().year
+
+    if isinstance(seasons, int):
+        assert seasons > 0, "Must generate fixture data for at least one season."
+
+        # We add 2, because we are open to the possibility of including matches
+        # from the current year in the data.
+        max_start_season = current_year - seasons + 2
+        start_season = np.random.choice(np.arange(FIRST_AFL_SEASON, max_start_season))
+        end_season = start_season + seasons
+        season_range = range(start_season, end_season)
+    elif isinstance(seasons, tuple):
+        assert (
+            len(seasons) == 2
+        ), f"Must provide two seasons to have a valid range, but {seasons} was given."
+
+        assert min(seasons) >= FIRST_AFL_SEASON and max(seasons) <= current_year + 1, (
+            f"Provided seasons must be in the range of {FIRST_AFL_SEASON} to "
+            f"{current_year + 1} (inclusive) to generate valid data."
+        )
+
+        assert (
+            seasons[0] < seasons[1]
+        ), "First season must be less than second to create a valid range."
+
+        season_range = range(*seasons)
+    else:
+        raise TypeError(
+            "seasons argument must be either an integer or a tuple of two integers"
+        )
+
+    return list(
+        chain.from_iterable([_generate_season(season) for season in season_range])
+    )

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,11 @@
 setuptools
 wheel
 twine
+
+# Testing/Linting
+pylint==2.6.0
+black
+faker
+pydocstyle==5.1.1
+pytest
+mypy>=0.70

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+numpy==1.19.1
+pandas==1.1.1
+
 # Package dependencies
 setuptools
 wheel

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,137 @@
+from datetime import date
+
+from faker import Faker
+import numpy as np
+import pandas as pd
+import pytest
+
+from candystore import fixtures
+
+
+FIXTURE_COLUMNS = {
+    "date",
+    "season",
+    "season_game",
+    "round",
+    "home_team",
+    "away_team",
+    "venue",
+}
+
+
+@pytest.fixture
+def int_seasons():
+    return np.random.randint(1, 10)
+
+
+@pytest.fixture
+def tuple_seasons():
+    current_year = date.today().year
+    seasons = np.random.randint(fixtures.FIRST_AFL_SEASON, current_year + 1, size=2)
+
+    return tuple(np.sort(seasons))
+
+
+@pytest.fixture(params=[int, tuple])
+def data(request):
+    if request.param == int:
+        seasons = np.random.randint(1, 10)
+    elif request.param == tuple:
+        current_year = date.today().year
+        years = np.random.randint(fixtures.FIRST_AFL_SEASON, current_year + 1, size=2)
+        seasons = tuple(np.sort(years))
+    else:
+        raise TypeError
+
+    return fixtures.generate(seasons=seasons)
+
+
+def test_non_postive_seasons():
+    # When seasons is <= 0, it raises an exception
+    seasons = np.random.randint(-10, 1)
+    with pytest.raises(AssertionError, match=r"at least one season"):
+        fixtures.generate(seasons=seasons)
+
+
+def test_too_long_tuple_seasons(tuple_seasons):
+    current_year = date.today().year
+    # When more than two seasons are given, it raises an exception
+    seasons = tuple(
+        sorted(
+            tuple_seasons
+            + (np.random.randint(fixtures.FIRST_AFL_SEASON, current_year + 1),)
+        )
+    )
+    with pytest.raises(AssertionError, match=r"provide two seasons"):
+        fixtures.generate(seasons=seasons)
+
+
+def test_seasons_out_of_range():
+    current_year = date.today().year
+    # When more than two seasons are given, it raises an exception
+    seasons = (fixtures.FIRST_AFL_SEASON, current_year + 1)
+
+    with pytest.raises(AssertionError, match=r"seasons must be in the range"):
+        fixtures.generate(seasons=(seasons[0] - 1, seasons[1]))
+
+    with pytest.raises(AssertionError, match=r"seasons must be in the range"):
+        fixtures.generate(seasons=(seasons[0], seasons[1] + 1))
+
+
+def test_seasons_out_of_order(tuple_seasons):
+    seasons = tuple(reversed(tuple_seasons))
+    with pytest.raises(AssertionError, match=r"First season must be less"):
+        fixtures.generate(seasons=seasons)
+
+
+def test_unknown_seasons_format(tuple_seasons):
+    seasons = list(tuple_seasons)
+    with pytest.raises(TypeError, match=r"seasons argument must be"):
+        fixtures.generate(seasons=seasons)
+
+
+def test_int_season_count(int_seasons):
+    data = fixtures.generate(seasons=int_seasons)
+    df = pd.DataFrame(data)
+
+    # It generates one season per requested season count
+    assert len(df["season"].drop_duplicates()) == int_seasons
+
+
+def test_tuple_season_count(tuple_seasons):
+    data = fixtures.generate(seasons=tuple_seasons)
+    df = pd.DataFrame(data)
+
+    first_season, last_season = tuple_seasons
+
+    # It generates seasons across the given season range
+    assert len(df["season"].drop_duplicates()) == last_season - first_season
+
+
+def test_data_structure(data):
+    # It returns a list of fixture dictionaries
+    assert isinstance(data, list)
+    assert isinstance(data[0], dict)
+    data_columns = set(data[0].keys())
+    assert FIXTURE_COLUMNS & data_columns == FIXTURE_COLUMNS
+
+
+def test_no_duplicate_teams(data):
+    df = pd.DataFrame(data)
+
+    # It doesn't have teams play more than once per round
+    round_groups = df.groupby(["season", "round"])
+    for _, season_round_df in round_groups:
+        teams = season_round_df[["home_team", "away_team"]].to_numpy().flatten()
+        assert len(teams) == len(np.unique(teams))
+
+
+def test_date_round_compatibility(data):
+    df = pd.DataFrame(data)
+
+    # It has rounds that increment with match dates
+    season_groups = df.groupby("season")
+    for _, season_df in season_groups:
+        date_sorted_rounds = season_df.sort_values("date")["round"].to_numpy()
+        sorted_rounds = season_df["round"].sort_values().to_numpy()
+        assert (date_sorted_rounds == sorted_rounds).all()


### PR DESCRIPTION
Copy/pasted, with some cleanup, from the data factory that I'm using in other projects. Decided to go with `pytest` instead of `unittest`, because everyone says it's better. I'll move some of the code in `fixtures` to a shared module of some sort as the codebase grows.