### PR TITLE
Only include one Brisbane team per round

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="candystore",
-    version="0.1.0",
+    version="0.1.1",
     author="Craig Franklin",
     author_email="craigjfranklin@gmail.com",
     description="Factories for randomised AFL data sets for testing purposes",

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -126,6 +126,17 @@ def test_no_duplicate_teams(data):
         assert len(teams) == len(np.unique(teams))
 
 
+def test_no_duplicate_brisbanes(data):
+    data_frame = pd.DataFrame(data)
+
+    # It only has one Brisbane team per round
+    round_groups = data_frame.groupby(["season", "round"])
+    for _, season_round_data_frame in round_groups:
+        teams = season_round_data_frame[["home_team", "away_team"]].to_numpy().flatten()
+        brisbane_teams = np.char.find(teams.astype("U"), "Brisbane") >= 0
+        assert len(teams[brisbane_teams]) == 1
+
+
 def test_date_round_compatibility(data):
     data_frame = pd.DataFrame(data)
 


### PR DESCRIPTION
It turns out that there isn't as much of a consensus on how to
treat the two Brisbane teams as I though. Even fitzRoy isn't
entirely consistent across data sets, sometimes including the
Brisbane Bears, sometimes converting all instances to Brisbane
Lions from the beginning. To avoid forcing users to pick a data
cleaning strategy, only including one Brisbane team should be a
simple way of avoiding generating invalid data regardless of how
data pipeliens deal with this.