### PR TITLE
Update numpy version range to <2.0

### DIFF
--- a/candystore/players.py
+++ b/candystore/players.py
@@ -113,12 +113,10 @@ BROWNLOW_VOTES_RANGE = (0, 4)
 N_PLAYERS_PER_TEAM = 22
 
 
-def _calculate_quarter_values(
-    value_range: Tuple[int, int], size: int
-) -> List[np.array]:
-    return [
-        (np.random.randint(*value_range, size=size) / 4).astype(int) for _ in range(4)
-    ]
+def _calculate_quarter_values(value_range: Tuple[int, int], size: int) -> np.ndarray:
+    return np.array(
+        [(np.random.randint(*value_range, size=size) / 4).astype(int) for _ in range(4)]
+    )
 
 
 def _parse_player_start_time(player_data_frame: pd.DataFrame) -> pd.Series:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     url="https://github.com/tipresias/candystore",
     packages=setuptools.find_packages(),
     install_requires=[
-        "numpy>=1.0,<1.20",
+        "numpy>=1.0,<2.0",
         "pandas>=0.24.0,<2.0",
         "faker>=4.0,<7.0",
         "mypy>=0.70,<1.0",


### PR DESCRIPTION
I downgraded the max permitted version of `numpy`, because the latest version broke some types, but it ended up being a simpler fix than I had thought. So, the max version is `<2.0` once again.