### PR TITLE
Run weekly build to test fitzRoy integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     env:
       CC_TEST_REPORTER_ID: d60734b9fc6663df40df650f2867d005e145acd5f741f34505a5e405f79ea784
     steps:
@@ -44,7 +44,7 @@ jobs:
         run: coverage run -m pytest --ignore tests/integration/
       - name: Upload test coverage report
         # Only do test coverage on latest version of Python to avoid duplication
-        if: ${{ matrix.python-version }} == 3.8
+        if: ${{ matrix.python-version }} == 3.9
         run: |
           coverage xml
           ./cc-test-reporter format-coverage -t coverage.py

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,15 @@
+name: fitzRoy integration
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the docker image
+        run: docker build -t candystore_tests .
+      - name: Run integration tests
+        run: ./scripts/integration_tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,30 @@
-FROM rpy2/base-ubuntu:v3.3.x-20.04
+# We use the rocker/tidyverse image instead of the rpy2 image,
+# because the latter doesn't get updated very often, and the web of
+# dependencies is delicate, which means old versions can break stuff.
+FROM rocker/tidyverse:4.0.0-ubuntu18.04
 
-RUN apt-get update \
-  && apt-get -y install libssl-dev
+RUN apt-get --no-install-recommends update \
+  && apt-get -y --no-install-recommends install software-properties-common \
+  && add-apt-repository ppa:deadsnakes/ppa
+# We need tzdata to avoid the following from readr:
+# Warning in OlsonNames() : no Olson database found
+# <simpleError: Unknown TZ UTC>
+RUN apt-get -y --no-install-recommends install \
+  tzdata \
+  python3-setuptools \
+  python3-pip \
+  python3.8
+
+# Need to set Python 3.8 as the default to override the included Python 3.6
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 
 WORKDIR /app
 
+# Need this so rpy2 can find the R installation
+RUN echo $(R RHOME)/lib > /etc/ld.so.conf.d/Rlib.conf \
+  && ldconfig
+
+RUN pip3 install --upgrade pip && pip3 install rpy2==3.4.3
 # Install Python dependencies
 # We bring extra files, because requirements.txt needs setup.py which needs
 # README.md, and I don't want to deal with maintaining multiple


### PR DESCRIPTION
I don't make frequent changes to this package, which runs the risk
of it getting out of sync with changes to fitzRoy's API. So, I'm
adding a weekly build that just tests that candystore is still
compatible with fitzRoy.

The new version of fitzRoy wasn't working with rpy2 + R v3.6.x,
so I had to change the base image to be able to use R v4.0.x.